### PR TITLE
Use player UUIDs instead of player names

### DIFF
--- a/src/main/java/net/gravitydevelopment/anticheat/AntiCheat.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/AntiCheat.java
@@ -20,6 +20,7 @@ package net.gravitydevelopment.anticheat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -142,14 +143,14 @@ public class AntiCheat extends JavaPlugin {
 
     private void restoreLevels() {
         for (Player player : getServer().getOnlinePlayers()) {
-            String name = player.getName();
+            UUID uuid = player.getUniqueId();
 
-            User user = new User(name);
+            User user = new User(uuid);
             user.setIsWaitingOnLevelSync(true);
             config.getLevels().loadLevelToUser(user);
 
             manager.getUserManager().addUser(user);
-            verboseLog("Data for " + name + " loaded");
+            verboseLog("Data for " + uuid + " loaded");
         }
     }
 

--- a/src/main/java/net/gravitydevelopment/anticheat/api/AntiCheatAPI.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/api/AntiCheatAPI.java
@@ -120,7 +120,7 @@ public class AntiCheatAPI {
      */
     @Deprecated
     public static int getLevel(Player player) {
-        return umr.safeGetLevel(player.getName());
+        return umr.safeGetLevel(player.getUniqueId());
     }
 
 
@@ -133,7 +133,7 @@ public class AntiCheatAPI {
      */
     @Deprecated
     public static void setLevel(Player player, int level) {
-        umr.safeSetLevel(player.getName(), level);
+        umr.safeSetLevel(player.getUniqueId(), level);
     }
 
     /**
@@ -142,7 +142,7 @@ public class AntiCheatAPI {
      * @param player Player to reset
      */
     public static void resetPlayer(Player player) {
-        umr.getUser(player.getName()).resetLevel();
+        umr.getUser(player.getUniqueId()).resetLevel();
     }
 
     /**
@@ -152,7 +152,7 @@ public class AntiCheatAPI {
      * @return The player's group
      */
     public static Group getGroup(Player player) {
-        return umr.getUser(player.getName()).getGroup();
+        return umr.getUser(player.getUniqueId()).getGroup();
     }
 
     /**

--- a/src/main/java/net/gravitydevelopment/anticheat/check/Backend.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/check/Backend.java
@@ -58,38 +58,38 @@ import net.gravitydevelopment.anticheat.util.VersionUtil;
 public class Backend {
     private List<UUID> isAscending = new ArrayList<UUID>();
     private Map<UUID, Integer> ascensionCount = new HashMap<UUID, Integer>();
-    private Map<String, Integer> chatLevel = new HashMap<String, Integer>();
-    private Map<String, Integer> commandLevel = new HashMap<String, Integer>();
-    private Map<String, Integer> nofallViolation = new HashMap<String, Integer>();
-    private Map<String, Integer> fastBreakViolation = new HashMap<String, Integer>();
-    private Map<String, Integer> fastBreaks = new HashMap<String, Integer>();
-    private Map<String, Boolean> blockBreakHolder = new HashMap<String, Boolean>();
-    private Map<String, Long> lastBlockBroken = new HashMap<String, Long>();
-    private Map<String, Integer> fastPlaceViolation = new HashMap<String, Integer>();
-    private Map<String, Long> lastBlockPlaced = new HashMap<String, Long>();
-    private Map<String, Long> lastBlockPlaceTime = new HashMap<String, Long>();
-    private Map<String, Integer> blockPunches = new HashMap<String, Integer>();
-    private Map<String, Integer> projectilesShot = new HashMap<String, Integer>();
-    private Map<String, Long> velocitized = new HashMap<String, Long>();
-    private Map<String, Integer> velocitytrack = new HashMap<String, Integer>();
-    private Map<String, Long> startEat = new HashMap<String, Long>();
-    private Map<String, Long> lastHeal = new HashMap<String, Long>();
-    private Map<String, Long> projectileTime = new HashMap<String, Long>();
-    private Map<String, Long> bowWindUp = new HashMap<String, Long>();
-    private Map<String, Long> instantBreakExempt = new HashMap<String, Long>();
-    private Map<String, Long> sprinted = new HashMap<String, Long>();
-    private Map<String, Long> brokenBlock = new HashMap<String, Long>();
-    private Map<String, Long> placedBlock = new HashMap<String, Long>();
-    private Map<String, Long> blockTime = new HashMap<String, Long>();
-    private Map<String, Integer> blocksDropped = new HashMap<String, Integer>();
-    private Map<String, Long> lastInventoryTime = new HashMap<String, Long>();
-    private Map<String, Long> inventoryTime = new HashMap<String, Long>();
-    private Map<String, Integer> inventoryClicks = new HashMap<String, Integer>();
-    private Map<String, Material> itemInHand = new HashMap<String, Material>();
-    private Map<String, Integer> steps = new HashMap<String, Integer>();
-    private Map<String, Long> stepTime = new HashMap<String, Long>();
+    private Map<UUID, Integer> chatLevel = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> commandLevel = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> nofallViolation = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> fastBreakViolation = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> fastBreaks = new HashMap<UUID, Integer>();
+    private Map<UUID, Boolean> blockBreakHolder = new HashMap<UUID, Boolean>();
+    private Map<UUID, Long> lastBlockBroken = new HashMap<UUID, Long>();
+    private Map<UUID, Integer> fastPlaceViolation = new HashMap<UUID, Integer>();
+    private Map<UUID, Long> lastBlockPlaced = new HashMap<UUID, Long>();
+    private Map<UUID, Long> lastBlockPlaceTime = new HashMap<UUID, Long>();
+    private Map<UUID, Integer> blockPunches = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> projectilesShot = new HashMap<UUID, Integer>();
+    private Map<UUID, Long> velocitized = new HashMap<UUID, Long>();
+    private Map<UUID, Integer> velocitytrack = new HashMap<UUID, Integer>();
+    private Map<UUID, Long> startEat = new HashMap<UUID, Long>();
+    private Map<UUID, Long> lastHeal = new HashMap<UUID, Long>();
+    private Map<UUID, Long> projectileTime = new HashMap<UUID, Long>();
+    private Map<UUID, Long> bowWindUp = new HashMap<UUID, Long>();
+    private Map<UUID, Long> instantBreakExempt = new HashMap<UUID, Long>();
+    private Map<UUID, Long> sprinted = new HashMap<UUID, Long>();
+    private Map<UUID, Long> brokenBlock = new HashMap<UUID, Long>();
+    private Map<UUID, Long> placedBlock = new HashMap<UUID, Long>();
+    private Map<UUID, Long> blockTime = new HashMap<UUID, Long>();
+    private Map<UUID, Integer> blocksDropped = new HashMap<UUID, Integer>();
+    private Map<UUID, Long> lastInventoryTime = new HashMap<UUID, Long>();
+    private Map<UUID, Long> inventoryTime = new HashMap<UUID, Long>();
+    private Map<UUID, Integer> inventoryClicks = new HashMap<UUID, Integer>();
+    private Map<UUID, Material> itemInHand = new HashMap<UUID, Material>();
+    private Map<UUID, Integer> steps = new HashMap<UUID, Integer>();
+    private Map<UUID, Long> stepTime = new HashMap<UUID, Long>();
     private HashSet<Byte> transparent = new HashSet<Byte>();
-    private Map<String, Long> lastFallPacket = new HashMap<String, Long>();
+    private Map<UUID, Long> lastFallPacket = new HashMap<UUID, Long>();
 
     private Magic magic;
     private AntiCheatManager manager = null;
@@ -113,77 +113,77 @@ public class Backend {
     }
 
     public void resetChatLevel(User user) {
-        chatLevel.put(user.getName(), 0);
+        chatLevel.put(user.getUUID(), 0);
     }
 
     public void garbageClean(Player player) {
-        String pN = player.getName();
+        UUID pU = player.getUniqueId();
 
         VelocityCheck.cleanPlayer(player);
         KillAuraCheck.cleanPlayer(player);
         BlinkCheck.MOVE_COUNT.remove(player.getUniqueId());
-        blocksDropped.remove(pN);
-        blockTime.remove(pN);
-        FlightCheck.movingExempt.remove(pN);
-        brokenBlock.remove(pN);
-        placedBlock.remove(pN);
-        bowWindUp.remove(pN);
-        startEat.remove(pN);
-        lastHeal.remove(pN);
-        sprinted.remove(pN);
-        WaterWalkCheck.isInWater.remove(pN);
-        WaterWalkCheck.isInWaterCache.remove(pN);
-        instantBreakExempt.remove(pN);
+        blocksDropped.remove(pU);
+        blockTime.remove(pU);
+        FlightCheck.movingExempt.remove(pU);
+        brokenBlock.remove(pU);
+        placedBlock.remove(pU);
+        bowWindUp.remove(pU);
+        startEat.remove(pU);
+        lastHeal.remove(pU);
+        sprinted.remove(pU);
+        WaterWalkCheck.isInWater.remove(pU);
+        WaterWalkCheck.isInWaterCache.remove(pU);
+        instantBreakExempt.remove(pU);
         isAscending.remove(player.getUniqueId());
         ascensionCount.remove(player.getUniqueId());
-        FlightCheck.blocksOverFlight.remove(pN);
-        nofallViolation.remove(pN);
-        fastBreakViolation.remove(pN);
-        YAxisCheck.yAxisViolations.remove(pN);
-        YAxisCheck.yAxisLastViolation.remove(pN);
-        YAxisCheck.lastYcoord.remove(pN);
-        YAxisCheck.lastYtime.remove(pN);
-        fastBreaks.remove(pN);
-        blockBreakHolder.remove(pN);
-        lastBlockBroken.remove(pN);
-        fastPlaceViolation.remove(pN);
-        lastBlockPlaced.remove(pN);
-        lastBlockPlaceTime.remove(pN);
-        blockPunches.remove(pN);
-        WaterWalkCheck.waterAscensionViolation.remove(pN);
-        WaterWalkCheck.waterSpeedViolation.remove(pN);
-        projectilesShot.remove(pN);
-        velocitized.remove(pN);
-        velocitytrack.remove(pN);
-        startEat.remove(pN);
-        lastHeal.remove(pN);
-        projectileTime.remove(pN);
-        bowWindUp.remove(pN);
-        instantBreakExempt.remove(pN);
-        sprinted.remove(pN);
-        brokenBlock.remove(pN);
-        placedBlock.remove(pN);
-        FlightCheck.movingExempt.remove(pN);
-        blockTime.remove(pN);
-        blocksDropped.remove(pN);
-        lastInventoryTime.remove(pN);
-        inventoryTime.remove(pN);
-        inventoryClicks.remove(pN);
-        lastFallPacket.remove(pN);
-        GlideCheck.lastYDelta.remove(pN);
-        GlideCheck.glideBuffer.remove(pN);
+        FlightCheck.blocksOverFlight.remove(pU);
+        nofallViolation.remove(pU);
+        fastBreakViolation.remove(pU);
+        YAxisCheck.yAxisViolations.remove(pU);
+        YAxisCheck.yAxisLastViolation.remove(pU);
+        YAxisCheck.lastYcoord.remove(pU);
+        YAxisCheck.lastYtime.remove(pU);
+        fastBreaks.remove(pU);
+        blockBreakHolder.remove(pU);
+        lastBlockBroken.remove(pU);
+        fastPlaceViolation.remove(pU);
+        lastBlockPlaced.remove(pU);
+        lastBlockPlaceTime.remove(pU);
+        blockPunches.remove(pU);
+        WaterWalkCheck.waterAscensionViolation.remove(pU);
+        WaterWalkCheck.waterSpeedViolation.remove(pU);
+        projectilesShot.remove(pU);
+        velocitized.remove(pU);
+        velocitytrack.remove(pU);
+        startEat.remove(pU);
+        lastHeal.remove(pU);
+        projectileTime.remove(pU);
+        bowWindUp.remove(pU);
+        instantBreakExempt.remove(pU);
+        sprinted.remove(pU);
+        brokenBlock.remove(pU);
+        placedBlock.remove(pU);
+        FlightCheck.movingExempt.remove(pU);
+        blockTime.remove(pU);
+        blocksDropped.remove(pU);
+        lastInventoryTime.remove(pU);
+        inventoryTime.remove(pU);
+        inventoryClicks.remove(pU);
+        lastFallPacket.remove(pU);
+        GlideCheck.lastYDelta.remove(pU);
+        GlideCheck.glideBuffer.remove(pU);
         SpeedCheck.speedViolation.remove(player.getUniqueId());
     }
 
     public CheckResult checkFastBow(Player player, float force) {
         // Ignore magic numbers here, they are minecrafty vanilla stuff.
-        int ticks = (int) ((((System.currentTimeMillis() - bowWindUp.get(player.getName())) * 20) / 1000) + 3);
-        bowWindUp.remove(player.getName());
+        int ticks = (int) ((((System.currentTimeMillis() - bowWindUp.get(player.getUniqueId())) * 20) / 1000) + 3);
+        bowWindUp.remove(player.getUniqueId());
         float f = (float) ticks / 20.0F;
         f = (f * f + f * 2.0F) / 3.0F;
         f = f > 1.0F ? 1.0F : f;
         if (Math.abs(force - f) > magic.BOW_ERROR()) {
-            return new CheckResult(CheckResult.Result.FAILED, player.getName() + " fired their bow too fast (actual force=" + force + ", calculated force=" + f + ")");
+            return new CheckResult(CheckResult.Result.FAILED, player.getUniqueId() + " fired their bow too fast (actual force=" + force + ", calculated force=" + f + ")");
         } else {
             return PASS;
         }
@@ -191,13 +191,13 @@ public class Backend {
 
     public CheckResult checkProjectile(Player player) {
     	incrementOld(player, projectilesShot, 10);
-        if (!projectileTime.containsKey(player.getName())) {
-            projectileTime.put(player.getName(), System.currentTimeMillis());
+        if (!projectileTime.containsKey(player.getUniqueId())) {
+            projectileTime.put(player.getUniqueId(), System.currentTimeMillis());
             return new CheckResult(CheckResult.Result.PASSED);
-        } else if (projectilesShot.get(player.getName()) == magic.PROJECTILE_CHECK()) {
-            long time = System.currentTimeMillis() - projectileTime.get(player.getName());
-            projectileTime.remove(player.getName());
-            projectilesShot.remove(player.getName());
+        } else if (projectilesShot.get(player.getUniqueId()) == magic.PROJECTILE_CHECK()) {
+            long time = System.currentTimeMillis() - projectileTime.get(player.getUniqueId());
+            projectileTime.remove(player.getUniqueId());
+            projectilesShot.remove(player.getUniqueId());
             if (time < magic.PROJECTILE_TIME_MIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " wound up a bow too fast (actual time=" + time + ", min time=" + magic.PROJECTILE_TIME_MIN() + ")");
             }
@@ -207,13 +207,13 @@ public class Backend {
 
     public CheckResult checkFastDrop(Player player) {
     	incrementOld(player, blocksDropped, 10);
-        if (!blockTime.containsKey(player.getName())) {
-            blockTime.put(player.getName(), System.currentTimeMillis());
+        if (!blockTime.containsKey(player.getUniqueId())) {
+            blockTime.put(player.getUniqueId(), System.currentTimeMillis());
             return new CheckResult(CheckResult.Result.PASSED);
-        } else if (blocksDropped.get(player.getName()) == magic.DROP_CHECK()) {
-            long time = System.currentTimeMillis() - blockTime.get(player.getName());
-            blockTime.remove(player.getName());
-            blocksDropped.remove(player.getName());
+        } else if (blocksDropped.get(player.getUniqueId()) == magic.DROP_CHECK()) {
+            long time = System.currentTimeMillis() - blockTime.get(player.getUniqueId());
+            blockTime.remove(player.getUniqueId());
+            blocksDropped.remove(player.getUniqueId());
             if (time < magic.DROP_TIME_MIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " dropped an item too fast (actual time=" + time + ", min time=" + magic.DROP_TIME_MIN() + ")");
             }
@@ -266,24 +266,24 @@ public class Backend {
     }
 
     public CheckResult checkNoFall(Player player, double y) {
-        String name = player.getName();
+        UUID uuid = player.getUniqueId();
         if (player.getGameMode() != GameMode.CREATIVE && !player.isInsideVehicle() && !player.isSleeping() && !isMovingExempt(player) && !justPlaced(player) && !Utilities.isInWater(player) && !Utilities.isInWeb(player)) {
             if (player.getFallDistance() == 0) {
-                if (nofallViolation.get(name) == null) {
-                    nofallViolation.put(name, 1);
+                if (nofallViolation.get(uuid) == null) {
+                    nofallViolation.put(uuid, 1);
                 } else {
-                    nofallViolation.put(name, nofallViolation.get(player.getName()) + 1);
+                    nofallViolation.put(uuid, nofallViolation.get(player.getUniqueId()) + 1);
                 }
 
-                int i = nofallViolation.get(name);
+                int i = nofallViolation.get(uuid);
                 if (i >= magic.NOFALL_LIMIT()) {
-                    nofallViolation.put(player.getName(), 1);
+                    nofallViolation.put(player.getUniqueId(), 1);
                     return new CheckResult(CheckResult.Result.FAILED, player.getName() + " tried to avoid fall damage (fall distance = 0 " + i + " times in a row, max=" + magic.NOFALL_LIMIT() + ")");
                 } else {
                     return PASS;
                 }
             } else {
-                nofallViolation.put(name, 0);
+                nofallViolation.put(uuid, 0);
                 return PASS;
             }
         }
@@ -338,18 +338,18 @@ public class Backend {
     }
 
     public CheckResult checkTimer(Player player) {
-        String name = player.getName();
+        UUID uuid = player.getUniqueId();
         int step = 1;
-        if (steps.containsKey(name)) {
-            step = steps.get(name) + 1;
+        if (steps.containsKey(uuid)) {
+            step = steps.get(uuid) + 1;
         }
         if (step == 1) {
-            stepTime.put(name, System.currentTimeMillis());
+            stepTime.put(uuid, System.currentTimeMillis());
         }
         incrementOld(player, steps, step);
         if (step == magic.TIMER_STEP_CHECK()) {
-            long time = System.currentTimeMillis() - stepTime.get(name);
-            steps.put(name, 0);
+            long time = System.currentTimeMillis() - stepTime.get(uuid);
+            steps.put(uuid, 0);
             if (time < magic.TIMER_TIMEMIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " tried to alter their timer, took " + step + " steps in " + time + " ms (min = " + magic.TIMER_TIMEMIN() + " ms)");
             }
@@ -426,15 +426,15 @@ public class Backend {
     }
 
     public CheckResult checkSwing(Player player, Block block) {
-        String name = player.getName();
+        UUID uuid = player.getUniqueId();
         if (!isInstantBreakExempt(player)) {
             if (!player.getInventory().getItemInHand().containsEnchantment(Enchantment.DIG_SPEED) && !(player.getInventory().getItemInHand().getType() == Material.SHEARS && block.getType() == Material.LEAVES)) {
-                if (blockPunches.get(name) != null && player.getGameMode() != GameMode.CREATIVE) {
-                    int i = blockPunches.get(name);
+                if (blockPunches.get(uuid) != null && player.getGameMode() != GameMode.CREATIVE) {
+                    int i = blockPunches.get(uuid);
                     if (i < magic.BLOCK_PUNCH_MIN()) {
                         return new CheckResult(CheckResult.Result.FAILED, player.getName() + " tried to break a block of " + block.getType() + " after only " + i + " punches (min=" + magic.BLOCK_PUNCH_MIN() + ")");
                     } else {
-                        blockPunches.put(name, 0); // it should reset after EACH block break.
+                        blockPunches.put(uuid, 0); // it should reset after EACH block break.
                     }
                 }
             }
@@ -449,118 +449,118 @@ public class Backend {
             violations = magic.FASTBREAK_MAXVIOLATIONS_CREATIVE();
             timemax = magic.FASTBREAK_TIMEMAX_CREATIVE();
         }
-        String name = player.getName();
-        if (!fastBreakViolation.containsKey(name)) {
-            fastBreakViolation.put(name, 0);
+        UUID uuid = player.getUniqueId();
+        if (!fastBreakViolation.containsKey(uuid)) {
+            fastBreakViolation.put(uuid, 0);
         } else {
-            Long math = System.currentTimeMillis() - lastBlockBroken.get(name);
-            int i = fastBreakViolation.get(name);
+            Long math = System.currentTimeMillis() - lastBlockBroken.get(uuid);
+            int i = fastBreakViolation.get(uuid);
             if (i > violations && math < magic.FASTBREAK_MAXVIOLATIONTIME()) {
-                lastBlockBroken.put(name, System.currentTimeMillis());
+                lastBlockBroken.put(uuid, System.currentTimeMillis());
                 if (!silentMode()) {
                     player.sendMessage(ChatColor.RED + "[AntiCheat] Fastbreaking detected. Please wait 10 seconds before breaking blocks.");
                 }
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " broke blocks too fast " + i + " times in a row (max=" + violations + ")");
-            } else if (fastBreakViolation.get(name) > 0 && math > magic.FASTBREAK_MAXVIOLATIONTIME()) {
-                fastBreakViolation.put(name, 0);
+            } else if (fastBreakViolation.get(uuid) > 0 && math > magic.FASTBREAK_MAXVIOLATIONTIME()) {
+                fastBreakViolation.put(uuid, 0);
             }
         }
-        if (!fastBreaks.containsKey(name) || !lastBlockBroken.containsKey(name)) {
-            if (!lastBlockBroken.containsKey(name)) {
-                lastBlockBroken.put(name, System.currentTimeMillis());
+        if (!fastBreaks.containsKey(uuid) || !lastBlockBroken.containsKey(uuid)) {
+            if (!lastBlockBroken.containsKey(uuid)) {
+                lastBlockBroken.put(uuid, System.currentTimeMillis());
             }
-            if (!fastBreaks.containsKey(name)) {
-                fastBreaks.put(name, 0);
+            if (!fastBreaks.containsKey(uuid)) {
+                fastBreaks.put(uuid, 0);
             }
         } else {
-            Long math = System.currentTimeMillis() - lastBlockBroken.get(name);
+            Long math = System.currentTimeMillis() - lastBlockBroken.get(uuid);
             if ((math != 0L && timemax != 0L)) {
                 if (math < timemax) {
-                    if (fastBreakViolation.containsKey(name) && fastBreakViolation.get(name) > 0) {
-                        fastBreakViolation.put(name, fastBreakViolation.get(name) + 1);
+                    if (fastBreakViolation.containsKey(uuid) && fastBreakViolation.get(uuid) > 0) {
+                        fastBreakViolation.put(uuid, fastBreakViolation.get(uuid) + 1);
                     } else {
-                        fastBreaks.put(name, fastBreaks.get(name) + 1);
+                        fastBreaks.put(uuid, fastBreaks.get(uuid) + 1);
                     }
-                    blockBreakHolder.put(name, false);
+                    blockBreakHolder.put(uuid, false);
                 }
-                if (fastBreaks.get(name) >= magic.FASTBREAK_LIMIT() && math < timemax) {
-                    int i = fastBreaks.get(name);
-                    fastBreaks.put(name, 0);
-                    fastBreakViolation.put(name, fastBreakViolation.get(name) + 1);
+                if (fastBreaks.get(uuid) >= magic.FASTBREAK_LIMIT() && math < timemax) {
+                    int i = fastBreaks.get(uuid);
+                    fastBreaks.put(uuid, 0);
+                    fastBreakViolation.put(uuid, fastBreakViolation.get(uuid) + 1);
                     return new CheckResult(CheckResult.Result.FAILED, player.getName() + " tried to break " + i + " blocks in " + math + " ms (max=" + magic.FASTBREAK_LIMIT() + " in " + timemax + " ms)");
-                } else if (fastBreaks.get(name) >= magic.FASTBREAK_LIMIT() || fastBreakViolation.get(name) > 0) {
-                    if (!blockBreakHolder.containsKey(name) || !blockBreakHolder.get(name)) {
-                        blockBreakHolder.put(name, true);
+                } else if (fastBreaks.get(uuid) >= magic.FASTBREAK_LIMIT() || fastBreakViolation.get(uuid) > 0) {
+                    if (!blockBreakHolder.containsKey(uuid) || !blockBreakHolder.get(uuid)) {
+                        blockBreakHolder.put(uuid, true);
                     } else {
-                        fastBreaks.put(name, fastBreaks.get(name) - 1);
-                        if (fastBreakViolation.get(name) > 0) {
-                            fastBreakViolation.put(name, fastBreakViolation.get(name) - 1);
+                        fastBreaks.put(uuid, fastBreaks.get(uuid) - 1);
+                        if (fastBreakViolation.get(uuid) > 0) {
+                            fastBreakViolation.put(uuid, fastBreakViolation.get(uuid) - 1);
                         }
-                        blockBreakHolder.put(name, false);
+                        blockBreakHolder.put(uuid, false);
                     }
                 }
             }
         }
 
-        lastBlockBroken.put(name, System.currentTimeMillis()); // always keep a log going.
+        lastBlockBroken.put(uuid, System.currentTimeMillis()); // always keep a log going.
         return PASS;
     }
 
     public CheckResult checkFastPlace(Player player) {
         int violations = player.getGameMode() == GameMode.CREATIVE ? magic.FASTPLACE_MAXVIOLATIONS_CREATIVE() : magic.FASTPLACE_MAXVIOLATIONS();
         long time = System.currentTimeMillis();
-        String name = player.getName();
-        if (!lastBlockPlaceTime.containsKey(name) || !fastPlaceViolation.containsKey(name)) {
-            lastBlockPlaceTime.put(name, 0L);
-            if (!fastPlaceViolation.containsKey(name)) {
-                fastPlaceViolation.put(name, 0);
+        UUID uuid = player.getUniqueId();
+        if (!lastBlockPlaceTime.containsKey(uuid) || !fastPlaceViolation.containsKey(uuid)) {
+            lastBlockPlaceTime.put(uuid, 0L);
+            if (!fastPlaceViolation.containsKey(uuid)) {
+                fastPlaceViolation.put(uuid, 0);
             }
-        } else if (fastPlaceViolation.containsKey(name) && fastPlaceViolation.get(name) > violations) {
-            AntiCheat.debugLog("Noted that fastPlaceViolation contains key " + name + " with value " + fastPlaceViolation.get(name));
-            Long math = System.currentTimeMillis() - lastBlockPlaced.get(name);
+        } else if (fastPlaceViolation.containsKey(uuid) && fastPlaceViolation.get(uuid) > violations) {
+            AntiCheat.debugLog("Noted that fastPlaceViolation contains key " + uuid + " with value " + fastPlaceViolation.get(uuid));
+            Long math = System.currentTimeMillis() - lastBlockPlaced.get(uuid);
             AntiCheat.debugLog("Player lastBlockPlaced value = " + lastBlockPlaced + ", diff=" + math);
-            if (lastBlockPlaced.get(name) > 0 && math < magic.FASTPLACE_MAXVIOLATIONTIME()) {
-                lastBlockPlaced.put(name, time);
+            if (lastBlockPlaced.get(uuid) > 0 && math < magic.FASTPLACE_MAXVIOLATIONTIME()) {
+                lastBlockPlaced.put(uuid, time);
                 if (!silentMode()) {
                     player.sendMessage(ChatColor.RED + "[AntiCheat] Fastplacing detected. Please wait 10 seconds before placing blocks.");
                 }
-                return new CheckResult(CheckResult.Result.FAILED, player.getName() + " placed blocks too fast " + fastBreakViolation.get(name) + " times in a row (max=" + violations + ")");
-            } else if (lastBlockPlaced.get(name) > 0 && math > magic.FASTPLACE_MAXVIOLATIONTIME()) {
-                AntiCheat.debugLog("Reset facePlaceViolation for " + name);
-                fastPlaceViolation.put(name, 0);
+                return new CheckResult(CheckResult.Result.FAILED, player.getName() + " placed blocks too fast " + fastBreakViolation.get(uuid) + " times in a row (max=" + violations + ")");
+            } else if (lastBlockPlaced.get(uuid) > 0 && math > magic.FASTPLACE_MAXVIOLATIONTIME()) {
+                AntiCheat.debugLog("Reset facePlaceViolation for " + uuid);
+                fastPlaceViolation.put(uuid, 0);
             }
-        } else if (lastBlockPlaced.containsKey(name)) {
-            long last = lastBlockPlaced.get(name);
-            long lastTime = lastBlockPlaceTime.get(name);
+        } else if (lastBlockPlaced.containsKey(uuid)) {
+            long last = lastBlockPlaced.get(uuid);
+            long lastTime = lastBlockPlaceTime.get(uuid);
             long thisTime = time - last;
 
             if (lastTime != 0 && thisTime < magic.FASTPLACE_TIMEMIN()) {
-                lastBlockPlaceTime.put(name, (time - last));
-                lastBlockPlaced.put(name, time);
-                fastPlaceViolation.put(name, fastPlaceViolation.get(name) + 1);
+                lastBlockPlaceTime.put(uuid, (time - last));
+                lastBlockPlaced.put(uuid, time);
+                fastPlaceViolation.put(uuid, fastPlaceViolation.get(uuid) + 1);
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " tried to place a block " + thisTime + " ms after the last one (min=" + magic.FASTPLACE_TIMEMIN() + " ms)");
             }
-            lastBlockPlaceTime.put(name, (time - last));
+            lastBlockPlaceTime.put(uuid, (time - last));
         }
-        lastBlockPlaced.put(name, time);
+        lastBlockPlaced.put(uuid, time);
         return PASS;
     }
 
     public void logBowWindUp(Player player) {
-        bowWindUp.put(player.getName(), System.currentTimeMillis());
+        bowWindUp.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public void logEatingStart(Player player) {
-        startEat.put(player.getName(), System.currentTimeMillis());
+        startEat.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public void logHeal(Player player) {
-        lastHeal.put(player.getName(), System.currentTimeMillis());
+        lastHeal.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public CheckResult checkChatSpam(Player player, String msg) {
-        String name = player.getName();
-        User user = manager.getUserManager().getUser(name);
+        UUID uuid = player.getUniqueId();
+        User user = manager.getUserManager().getUser(uuid);
         if (user.getLastMessageTime() != -1) {
             for (int i = 0; i < 2; i++) {
                 String m = user.getMessage(i);
@@ -588,8 +588,8 @@ public class Backend {
     }
 
     public CheckResult checkCommandSpam(Player player, String cmd) {
-        String name = player.getName();
-        User user = manager.getUserManager().getUser(name);
+        UUID uuid = player.getUniqueId();
+        User user = manager.getUserManager().getUser(uuid);
         if (user.getLastCommandTime() != -1) {
             for (int i = 0; i < 2; i++) {
                 String m = user.getCommand(i);
@@ -618,17 +618,17 @@ public class Backend {
         if (player.getGameMode() == GameMode.CREATIVE) {
             return PASS;
         }
-        String name = player.getName();
+        UUID uuid = player.getUniqueId();
         int clicks = 1;
-        if (inventoryClicks.containsKey(name)) {
-            clicks = inventoryClicks.get(name) + 1;
+        if (inventoryClicks.containsKey(uuid)) {
+            clicks = inventoryClicks.get(uuid) + 1;
         }
-        inventoryClicks.put(name, clicks);
+        inventoryClicks.put(uuid, clicks);
         if (clicks == 1) {
-            inventoryTime.put(name, System.currentTimeMillis());
+            inventoryTime.put(uuid, System.currentTimeMillis());
         } else if (clicks == magic.INVENTORY_CHECK()) {
-            long time = System.currentTimeMillis() - inventoryTime.get(name);
-            inventoryClicks.put(name, 0);
+            long time = System.currentTimeMillis() - inventoryTime.get(uuid);
+            inventoryClicks.put(uuid, 0);
             if (time < magic.INVENTORY_TIMEMIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " clicked inventory slots " + clicks + " times in " + time + " ms (max=" + magic.INVENTORY_CHECK() + " in " + magic.INVENTORY_TIMEMIN() + " ms)");
             }
@@ -637,7 +637,7 @@ public class Backend {
     }
 
     public CheckResult checkAutoTool(Player player) {
-        if (itemInHand.containsKey(player.getName()) && itemInHand.get(player.getName()) != player.getItemInHand().getType()) {
+        if (itemInHand.containsKey(player.getUniqueId()) && itemInHand.get(player.getUniqueId()) != player.getItemInHand().getType()) {
             return new CheckResult(CheckResult.Result.FAILED, player.getName() + " switched tools too fast (had " + itemInHand.get(player.getName()) + ", has " + player.getItemInHand().getType() + ")");
         } else {
             return PASS;
@@ -653,10 +653,10 @@ public class Backend {
     }
 
     public CheckResult checkFastHeal(Player player) {
-        if (lastHeal.containsKey(player.getName())) // Otherwise it was modified by a plugin, don't worry about it.
+        if (lastHeal.containsKey(player.getUniqueId())) // Otherwise it was modified by a plugin, don't worry about it.
         {
-            long l = lastHeal.get(player.getName());
-            lastHeal.remove(player.getName());
+            long l = lastHeal.get(player.getUniqueId());
+            lastHeal.remove(player.getUniqueId());
             if ((System.currentTimeMillis() - l) < magic.HEAL_TIME_MIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " healed too quickly (time=" + (System.currentTimeMillis() - l) + " ms, min=" + magic.HEAL_TIME_MIN() + " ms)");
             }
@@ -665,10 +665,10 @@ public class Backend {
     }
 
     public CheckResult checkFastEat(Player player) {
-        if (startEat.containsKey(player.getName())) // Otherwise it was modified by a plugin, don't worry about it.
+        if (startEat.containsKey(player.getUniqueId())) // Otherwise it was modified by a plugin, don't worry about it.
         {
-            long l = startEat.get(player.getName());
-            startEat.remove(player.getName());
+            long l = startEat.get(player.getUniqueId());
+            startEat.remove(player.getUniqueId());
             if ((System.currentTimeMillis() - l) < magic.EAT_TIME_MIN()) {
                 return new CheckResult(CheckResult.Result.FAILED, player.getName() + " ate too quickly (time=" + (System.currentTimeMillis() - l) + " ms, min=" + magic.EAT_TIME_MIN() + " ms)");
             }
@@ -677,7 +677,7 @@ public class Backend {
     }
 
     public void logInstantBreak(final Player player) {
-        instantBreakExempt.put(player.getName(), System.currentTimeMillis());
+        instantBreakExempt.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public boolean isInstantBreakExempt(Player player) {
@@ -685,12 +685,12 @@ public class Backend {
     }
 
     public void logSprint(final Player player) {
-        sprinted.put(player.getName(), System.currentTimeMillis());
+        sprinted.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public boolean isHoveringOverWaterAfterViolation(Player player) {
-        if (WaterWalkCheck.waterSpeedViolation.containsKey(player.getName())) {
-            if (WaterWalkCheck.waterSpeedViolation.get(player.getName()) >= magic.WATER_SPEED_VIOLATION_MAX() && Utilities.isHoveringOverWater(player.getLocation())) {
+        if (WaterWalkCheck.waterSpeedViolation.containsKey(player.getUniqueId())) {
+            if (WaterWalkCheck.waterSpeedViolation.get(player.getUniqueId()) >= magic.WATER_SPEED_VIOLATION_MAX() && Utilities.isHoveringOverWater(player.getLocation())) {
                 return true;
             }
         }
@@ -698,7 +698,7 @@ public class Backend {
     }
 
     public void logBlockBreak(final Player player) {
-        brokenBlock.put(player.getName(), System.currentTimeMillis());
+        brokenBlock.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public boolean justBroke(Player player) {
@@ -706,35 +706,35 @@ public class Backend {
     }
 
     public void logVelocity(final Player player) {
-        velocitized.put(player.getName(), System.currentTimeMillis());
+        velocitized.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public boolean justVelocity(Player player) {
-        return (velocitized.containsKey(player.getName()) ? (System.currentTimeMillis() - velocitized.get(player.getName())) < magic.VELOCITY_CHECKTIME() : false);
+        return (velocitized.containsKey(player.getUniqueId()) ? (System.currentTimeMillis() - velocitized.get(player.getUniqueId())) < magic.VELOCITY_CHECKTIME() : false);
     }
 
     public boolean extendVelocityTime(final Player player) {
-        if (velocitytrack.containsKey(player.getName())) {
-            velocitytrack.put(player.getName(), velocitytrack.get(player.getName()) + 1);
-            if (velocitytrack.get(player.getName()) > magic.VELOCITY_MAXTIMES()) {
-                velocitized.put(player.getName(), System.currentTimeMillis() + magic.VELOCITY_PREVENT());
+        if (velocitytrack.containsKey(player.getUniqueId())) {
+            velocitytrack.put(player.getUniqueId(), velocitytrack.get(player.getUniqueId()) + 1);
+            if (velocitytrack.get(player.getUniqueId()) > magic.VELOCITY_MAXTIMES()) {
+                velocitized.put(player.getUniqueId(), System.currentTimeMillis() + magic.VELOCITY_PREVENT());
                 manager.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(manager.getPlugin(), new Runnable() {
                     @Override
                     public void run() {
-                        velocitytrack.put(player.getName(), 0);
+                        velocitytrack.put(player.getUniqueId(), 0);
                     }
                 }, magic.VELOCITY_SCHETIME() * 20L);
                 return true;
             }
         } else {
-            velocitytrack.put(player.getName(), 0);
+            velocitytrack.put(player.getUniqueId(), 0);
         }
 
         return false;
     }
 
     public void logBlockPlace(final Player player) {
-        placedBlock.put(player.getName(), System.currentTimeMillis());
+        placedBlock.put(player.getUniqueId(), System.currentTimeMillis());
     }
 
     public boolean justPlaced(Player player) {
@@ -757,38 +757,38 @@ public class Backend {
                 break;
 
         }
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + time);
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + time);
         // Only map in which termination time is calculated beforehand.
     }
 
     public void logEnterExit(final Player player) {
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + magic.ENTERED_EXITED_TIME());
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + magic.ENTERED_EXITED_TIME());
     }
 
     public void logToggleSneak(final Player player) {
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + magic.SNEAK_TIME());
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + magic.SNEAK_TIME());
     }
 
     public void logTeleport(final Player player) {
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + magic.TELEPORT_TIME());
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + magic.TELEPORT_TIME());
 
         /* Data for fly/speed should be reset */
-        nofallViolation.remove(player.getName());
-        FlightCheck.blocksOverFlight.remove(player.getName());
-        YAxisCheck.yAxisViolations.remove(player.getName());
-        YAxisCheck.yAxisLastViolation.remove(player.getName());
-        YAxisCheck.lastYcoord.remove(player.getName());
-        YAxisCheck.lastYtime.remove(player.getName());
-        GlideCheck.lastYDelta.remove(player.getName());
-        GlideCheck.glideBuffer.remove(player.getName());
+        nofallViolation.remove(player.getUniqueId());
+        FlightCheck.blocksOverFlight.remove(player.getUniqueId());
+        YAxisCheck.yAxisViolations.remove(player.getUniqueId());
+        YAxisCheck.yAxisLastViolation.remove(player.getUniqueId());
+        YAxisCheck.lastYcoord.remove(player.getUniqueId());
+        YAxisCheck.lastYtime.remove(player.getUniqueId());
+        GlideCheck.lastYDelta.remove(player.getUniqueId());
+        GlideCheck.glideBuffer.remove(player.getUniqueId());
     }
 
     public void logExitFly(final Player player) {
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + magic.EXIT_FLY_TIME());
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + magic.EXIT_FLY_TIME());
     }
 
     public void logJoin(final Player player) {
-        FlightCheck.movingExempt.put(player.getName(), System.currentTimeMillis() + magic.JOIN_TIME());
+        FlightCheck.movingExempt.put(player.getUniqueId(), System.currentTimeMillis() + magic.JOIN_TIME());
     }
 
     public boolean isMovingExempt(Player player) {
@@ -796,22 +796,22 @@ public class Backend {
     }
 
     public boolean isAscending(Player player) {
-        return isAscending.contains(player.getName());
+        return isAscending.contains(player.getUniqueId());
     }
 
-    private boolean isDoing(Player player, Map<String, Long> map, double max) {
-        if (map.containsKey(player.getName())) {
+    private boolean isDoing(Player player, Map<UUID, Long> map, double max) {
+        if (map.containsKey(player.getUniqueId())) {
             if (max != -1) {
-                if (((System.currentTimeMillis() - map.get(player.getName())) / 1000) > max) {
-                    map.remove(player.getName());
+                if (((System.currentTimeMillis() - map.get(player.getUniqueId())) / 1000) > max) {
+                    map.remove(player.getUniqueId());
                     return false;
                 } else {
                     return true;
                 }
             } else {
                 // Termination time has already been calculated
-                if (map.get(player.getName()) < System.currentTimeMillis()) {
-                    map.remove(player.getName());
+                if (map.get(player.getUniqueId()) < System.currentTimeMillis()) {
+                    map.remove(player.getUniqueId());
                     return false;
                 } else {
                     return true;
@@ -831,23 +831,23 @@ public class Backend {
     }
 
     public void processChatSpammer(Player player) {
-        User user = manager.getUserManager().getUser(player.getName());
-        int level = chatLevel.containsKey(user.getName()) ? chatLevel.get(user.getName()) : 0;
+        User user = manager.getUserManager().getUser(player.getUniqueId());
+        int level = chatLevel.containsKey(user.getUUID()) ? chatLevel.get(user.getUUID()) : 0;
         if (player != null && player.isOnline() && level >= magic.CHAT_ACTION_ONE_LEVEL()) {
             String event = level >= magic.CHAT_ACTION_TWO_LEVEL() ? manager.getConfiguration().getConfig().chatSpamActionTwo.getValue() : manager.getConfiguration().getConfig().chatSpamActionOne.getValue();
-            manager.getUserManager().execute(manager.getUserManager().getUser(player.getName()), Utilities.stringToList(event), CheckType.CHAT_SPAM, lang.SPAM_KICK_REASON(), Utilities.stringToList(lang.SPAM_WARNING()), lang.SPAM_BAN_REASON());
+            manager.getUserManager().execute(manager.getUserManager().getUser(player.getUniqueId()), Utilities.stringToList(event), CheckType.CHAT_SPAM, lang.SPAM_KICK_REASON(), Utilities.stringToList(lang.SPAM_WARNING()), lang.SPAM_BAN_REASON());
         }
-        chatLevel.put(user.getName(), level + 1);
+        chatLevel.put(user.getUUID(), level + 1);
     }
 
     public void processCommandSpammer(Player player) {
-        User user = manager.getUserManager().getUser(player.getName());
-        int level = commandLevel.containsKey(user.getName()) ? commandLevel.get(user.getName()) : 0;
+        User user = manager.getUserManager().getUser(player.getUniqueId());
+        int level = commandLevel.containsKey(user.getUUID()) ? commandLevel.get(user.getUUID()) : 0;
         if (player != null && player.isOnline() && level >= magic.COMMAND_ACTION_ONE_LEVEL()) {
             String event = level >= magic.COMMAND_ACTION_TWO_LEVEL() ? manager.getConfiguration().getConfig().commandSpamActionTwo.getValue() : manager.getConfiguration().getConfig().commandSpamActionOne.getValue();
-            manager.getUserManager().execute(manager.getUserManager().getUser(player.getName()), Utilities.stringToList(event), CheckType.COMMAND_SPAM, lang.SPAM_KICK_REASON(), Utilities.stringToList(lang.SPAM_WARNING()), lang.SPAM_BAN_REASON());
+            manager.getUserManager().execute(manager.getUserManager().getUser(player.getUniqueId()), Utilities.stringToList(event), CheckType.COMMAND_SPAM, lang.SPAM_KICK_REASON(), Utilities.stringToList(lang.SPAM_WARNING()), lang.SPAM_BAN_REASON());
         }
-        commandLevel.put(user.getName(), level + 1);
+        commandLevel.put(user.getUUID(), level + 1);
     }
 
     public int increment(Player player, Map<UUID, Integer> ascensionCount2, int num) {
@@ -867,18 +867,18 @@ public class Backend {
         }
     }
     
-    public int incrementOld(Player player, Map<String, Integer> ascensionCount2, int num) {
-        String name = player.getName();
-        if (ascensionCount2.get(name) == null) {
-            ascensionCount2.put(name, 1);
+    public int incrementOld(Player player, Map<UUID, Integer> ascensionCount2, int num) {
+        UUID uuid = player.getUniqueId();
+        if (ascensionCount2.get(uuid) == null) {
+            ascensionCount2.put(uuid, 1);
             return 1;
         } else {
-            int amount = ascensionCount2.get(name) + 1;
+            int amount = ascensionCount2.get(uuid) + 1;
             if (amount < num + 1) {
-                ascensionCount2.put(name, amount);
+                ascensionCount2.put(uuid, amount);
                 return amount;
             } else {
-                ascensionCount2.put(name, num);
+                ascensionCount2.put(uuid, num);
                 return num;
             }
         }

--- a/src/main/java/net/gravitydevelopment/anticheat/check/CheckType.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/check/CheckType.java
@@ -26,6 +26,7 @@ import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * <p/>
@@ -64,7 +65,7 @@ public enum CheckType {
 	CRITICALS(Permission.CRITICALS);
 
     private final Permission permission;
-    private final Map<String, Integer> level = new HashMap<String, Integer>();
+    private final Map<UUID, Integer> level = new HashMap<UUID, Integer>();
 
     /**
      * Initialize a CheckType
@@ -91,28 +92,28 @@ public enum CheckType {
      * @param user User who failed the check
      */
     public void logUse(User user) {
-        int amount = level.get(user.getName()) == null ? 1 : level.get(user.getName()) + 1;
-        level.put(user.getName(), amount);
+        int amount = level.get(user.getUUID()) == null ? 1 : level.get(user.getUUID()) + 1;
+        level.put(user.getUUID(), amount);
         Bukkit.getServer().getPluginManager().callEvent(new CheckFailEvent(user, this));
     }
 
     /**
      * Clear failure history of this check for a user
      *
-     * @param name User's name to clear
+     * @param UUID User's UUID to clear
      */
-    public void clearUse(String name) {
-        level.put(name, 0);
+    public void clearUse(UUID uuid) {
+        level.put(uuid, 0);
     }
 
     /**
      * Get how many times a user has failed this check
      *
-     * @param name User's name
+     * @param UUID User's UUID
      * @return number of times failed
      */
-    public int getUses(String name) {
-        return level.get(name) != null ? level.get(name) : 0;
+    public int getUses(UUID uuid) {
+        return level.get(uuid) != null ? level.get(uuid) : 0;
     }
 
     /**

--- a/src/main/java/net/gravitydevelopment/anticheat/check/movement/FlightCheck.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/check/movement/FlightCheck.java
@@ -2,6 +2,7 @@ package net.gravitydevelopment.anticheat.check.movement;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -21,34 +22,34 @@ public class FlightCheck {
 
 	private static final CheckResult PASS = new CheckResult(CheckResult.Result.PASSED);
 	
-	public static Map<String, Double> blocksOverFlight = new HashMap<String, Double>();
-	public static Map<String, Long> movingExempt = new HashMap<String, Long>();
+	public static Map<UUID, Double> blocksOverFlight = new HashMap<UUID, Double>();
+	public static Map<UUID, Long> movingExempt = new HashMap<UUID, Long>();
 	
     public static CheckResult runCheck(Player player, Distance distance) {
         if (distance.getYDifference() > AntiCheat.getManager().getBackend().getMagic().TELEPORT_MIN()) {
             // This was a teleport, so we don't care about it.
             return PASS;
         }
-        final String name = player.getName();
+        final UUID uuid = player.getUniqueId();
         final double y1 = distance.fromY();
         final double y2 = distance.toY();
         if (!isMovingExempt(player) && !Utilities.isHoveringOverWater(player.getLocation(), 1) && Utilities.cantStandAtExp(player.getLocation()) && Utilities.blockIsnt(player.getLocation().getBlock().getRelative(BlockFace.DOWN), new Material[]{Material.FENCE, Material.FENCE_GATE, Material.COBBLE_WALL})) {
 
-            if (!blocksOverFlight.containsKey(name)) {
-                blocksOverFlight.put(name, 0D);
+            if (!blocksOverFlight.containsKey(uuid)) {
+                blocksOverFlight.put(uuid, 0D);
             }
 
-            blocksOverFlight.put(name, (blocksOverFlight.get(name) + distance.getXDifference() + distance.getYDifference() + distance.getZDifference()));
+            blocksOverFlight.put(uuid, (blocksOverFlight.get(uuid) + distance.getXDifference() + distance.getYDifference() + distance.getZDifference()));
 
             if (y1 > y2) {
-                blocksOverFlight.put(name, (blocksOverFlight.get(name) - distance.getYDifference()));
+                blocksOverFlight.put(uuid, (blocksOverFlight.get(uuid) - distance.getYDifference()));
             }
 
-            if (blocksOverFlight.get(name) > AntiCheat.getManager().getBackend().getMagic().FLIGHT_BLOCK_LIMIT() && (y1 <= y2)) {
-                return new CheckResult(CheckResult.Result.FAILED, player.getName() + " flew over " + blocksOverFlight.get(name) + " blocks (max=" + AntiCheat.getManager().getBackend().getMagic().FLIGHT_BLOCK_LIMIT() + ")");
+            if (blocksOverFlight.get(uuid) > AntiCheat.getManager().getBackend().getMagic().FLIGHT_BLOCK_LIMIT() && (y1 <= y2)) {
+                return new CheckResult(CheckResult.Result.FAILED, player.getName() + " flew over " + blocksOverFlight.get(uuid) + " blocks (max=" + AntiCheat.getManager().getBackend().getMagic().FLIGHT_BLOCK_LIMIT() + ")");
             }
         } else {
-            blocksOverFlight.put(name, 0D);
+            blocksOverFlight.put(uuid, 0D);
         }
 
         return PASS;
@@ -58,19 +59,19 @@ public class FlightCheck {
         return isDoing(player, movingExempt, -1);
     }
     
-    private static boolean isDoing(Player player, Map<String, Long> map, double max) {
-        if (map.containsKey(player.getName())) {
+    private static boolean isDoing(Player player, Map<UUID, Long> map, double max) {
+        if (map.containsKey(player.getUniqueId())) {
             if (max != -1) {
-                if (((System.currentTimeMillis() - map.get(player.getName())) / 1000) > max) {
-                    map.remove(player.getName());
+                if (((System.currentTimeMillis() - map.get(player.getUniqueId())) / 1000) > max) {
+                    map.remove(player.getUniqueId());
                     return false;
                 } else {
                     return true;
                 }
             } else {
                 // Termination time has already been calculated
-                if (map.get(player.getName()) < System.currentTimeMillis()) {
-                    map.remove(player.getName());
+                if (map.get(player.getUniqueId()) < System.currentTimeMillis()) {
+                    map.remove(player.getUniqueId());
                     return false;
                 } else {
                     return true;

--- a/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReport.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReport.java
@@ -30,6 +30,7 @@ import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class CommandReport extends CommandBase {
 
@@ -81,7 +82,7 @@ public class CommandReport extends CommandBase {
                 // Test users
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     if (player.getName().equalsIgnoreCase(args[0])) {
-                        User user = AntiCheat.getManager().getUserManager().getUser(args[0]);
+                        User user = AntiCheat.getManager().getUserManager().getUser(player.getUniqueId());
                         playerReport(cs, user, page);
                         return;
                     }
@@ -126,11 +127,12 @@ public class CommandReport extends CommandBase {
     private void playerReport(CommandSender cs, User user, int page) {
         List<CheckType> types = new ArrayList<CheckType>();
         for (CheckType type : CheckType.values()) {
-            if (type.getUses(user.getName()) > 0) {
+            if (type.getUses(user.getUUID()) > 0) {
                 types.add(type);
             }
         }
 
+        UUID uuid = user.getUUID();
         String name = user.getName();
         int pages = (int) Math.ceil(((float) types.size()) / 6);
 
@@ -150,7 +152,7 @@ public class CommandReport extends CommandBase {
                 int index = ((page - 1) * 5) + (x + ((page - 1)));
                 if (index < types.size()) {
                     CheckType type = types.get(index);
-                    int use = type.getUses(name);
+                    int use = type.getUses(uuid);
                     ChatColor color = WHITE;
                     if (use >= 20) {
                         color = YELLOW;

--- a/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReset.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReset.java
@@ -22,6 +22,8 @@ import net.gravitydevelopment.anticheat.AntiCheat;
 import net.gravitydevelopment.anticheat.command.CommandBase;
 import net.gravitydevelopment.anticheat.util.Permission;
 import net.gravitydevelopment.anticheat.util.User;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
 public class CommandReset extends CommandBase {
@@ -41,7 +43,7 @@ public class CommandReset extends CommandBase {
     @Override
     protected void execute(CommandSender cs, String[] args) {
         if (args.length == 1) {
-            User user = USER_MANAGER.getUser(args[0]);
+            User user = USER_MANAGER.getUser(Bukkit.getPlayer(args[0]).getUniqueId());
             if (user != null) {
                 user.resetLevel();
                 user.clearMessages();

--- a/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReset.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/command/executors/CommandReset.java
@@ -25,35 +25,41 @@ import net.gravitydevelopment.anticheat.util.User;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class CommandReset extends CommandBase {
 
-    private static final String NAME = "AntiCheat Resetting";
-    private static final String COMMAND = "reset";
-    private static final String USAGE = "anticheat reset [user]";
-    private static final Permission PERMISSION = Permission.SYSTEM_RESET;
-    private static final String[] HELP = {
-            GRAY + "Use: " + AQUA + "/anticheat reset [user]" + GRAY + " to reset this user's hack level",
-    };
+	private static final String NAME = "AntiCheat Resetting";
+	private static final String COMMAND = "reset";
+	private static final String USAGE = "anticheat reset [user]";
+	private static final Permission PERMISSION = Permission.SYSTEM_RESET;
+	private static final String[] HELP = {
+			GRAY + "Use: " + AQUA + "/anticheat reset [user]" + GRAY + " to reset this user's hack level",
+	};
 
-    public CommandReset() {
-        super(NAME, COMMAND, USAGE, HELP, PERMISSION);
-    }
+	public CommandReset() {
+		super(NAME, COMMAND, USAGE, HELP, PERMISSION);
+	}
 
-    @Override
-    protected void execute(CommandSender cs, String[] args) {
-        if (args.length == 1) {
-            User user = USER_MANAGER.getUser(Bukkit.getPlayer(args[0]).getUniqueId());
-            if (user != null) {
-                user.resetLevel();
-                user.clearMessages();
-                AntiCheat.getManager().getBackend().resetChatLevel(user);
-                cs.sendMessage(args[0] + GREEN + " has been reset.");
-            } else {
-                cs.sendMessage(RED + "Player: " +args[0] + " not found.");
-            }
-        } else {
-            sendHelp(cs);
-        }
-    }
+	@Override
+	protected void execute(CommandSender cs, String[] args) {
+		User user;
+		if (args.length == 1) {
+			if (Bukkit.getPlayer(args[0]) != null) {
+				user = USER_MANAGER.getUser(Bukkit.getPlayer(args[0]).getUniqueId());
+			} else {
+				user = USER_MANAGER.getUser(Bukkit.getOfflinePlayer(args[0]).getUniqueId());
+			}
+			if (user != null) {
+				user.resetLevel();
+				user.clearMessages();
+				AntiCheat.getManager().getBackend().resetChatLevel(user);
+				cs.sendMessage(args[0] + GREEN + " has been reset.");
+			} else {
+				cs.sendMessage(RED + "Player: " +args[0] + " not found.");
+			}
+		} else {
+			sendHelp(cs);
+		}
+	}
 }

--- a/src/main/java/net/gravitydevelopment/anticheat/config/holders/mysql/MySQLLevelsHolder.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/config/holders/mysql/MySQLLevelsHolder.java
@@ -70,6 +70,8 @@ public class MySQLLevelsHolder extends ConfigurationTable implements Levels {
             if (!tableExists()) {
                 getConnection().prepareStatement(sqlCreate).executeUpdate();
                 getConnection().commit();
+            } else if (!isUUIDFormatted("user")) {
+            	convertToUUID("user");
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -82,10 +84,10 @@ public class MySQLLevelsHolder extends ConfigurationTable implements Levels {
             @Override
             public void run() {
                 if (!user.isWaitingOnLevelSync()) {
-                    AntiCheat.debugLog("Saving level from " + user.getName() + ". Value: " + user.getLevel());
+                    AntiCheat.debugLog("Saving level from " + user.getUUID() + ". Value: " + user.getLevel());
                     try {
                         PreparedStatement statement = getConnection().prepareStatement(sqlSave);
-                        statement.setString(1, user.getName());
+                        statement.setString(1, user.getUUID().toString());
                         statement.setInt(2, user.getLevel());
                         statement.setString(3, getServerName());
                         statement.setTimestamp(4, user.getLevelSyncTimestamp());
@@ -110,14 +112,14 @@ public class MySQLLevelsHolder extends ConfigurationTable implements Levels {
             public void run() {
                 try {
                     PreparedStatement statement = getConnection().prepareStatement(sqlLoad);
-                    statement.setString(1, user.getName());
+                    statement.setString(1, user.getUUID().toString());
 
                     ResultSet set = statement.executeQuery();
 
                     boolean has = false;
                     while (set.next()) {
                         has = true;
-                        AntiCheat.debugLog("Syncing level to " + user.getName() + ". Value: " + set.getInt("level"));
+                        AntiCheat.debugLog("Syncing level to " + user.getUUID() + ". Value: " + set.getInt("level"));
                         user.setLevel(set.getInt("level"));
                         user.setLevelSyncTimestamp(set.getTimestamp("last_update"));
                     }
@@ -136,7 +138,7 @@ public class MySQLLevelsHolder extends ConfigurationTable implements Levels {
             for (User user : users) {
                 if (!user.isWaitingOnLevelSync()) {
                     try {
-                        statement.setString(1, user.getName());
+                        statement.setString(1, user.getUUID().toString());
                         statement.setInt(2, user.getLevel());
                         statement.setString(3, getServerName());
                         statement.setTimestamp(4, user.getLevelSyncTimestamp());
@@ -164,14 +166,14 @@ public class MySQLLevelsHolder extends ConfigurationTable implements Levels {
             public void run() {
                 try {
                     PreparedStatement statement = getConnection().prepareStatement(sqlUpdate);
-                    statement.setString(1, user.getName());
+                    statement.setString(1, user.getUUID().toString());
                     statement.setTimestamp(2, user.getLevelSyncTimestamp());
                     statement.setString(3, MANUAL_EDIT_TAG);
 
                     ResultSet set = statement.executeQuery();
 
                     while (set.next()) {
-                        AntiCheat.debugLog("Syncing level to " + user.getName() + ". Value: " + set.getInt("level"));
+                        AntiCheat.debugLog("Syncing level to " + user.getUUID() + ". Value: " + set.getInt("level"));
                         user.setLevel(set.getInt("level"));
                         user.setLevelSyncTimestamp(set.getTimestamp("last_update"));
                     }

--- a/src/main/java/net/gravitydevelopment/anticheat/config/holders/yaml/YamlLevelsHolder.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/config/holders/yaml/YamlLevelsHolder.java
@@ -25,6 +25,7 @@ import net.gravitydevelopment.anticheat.config.providers.Levels;
 import net.gravitydevelopment.anticheat.util.User;
 
 import java.util.List;
+import java.util.UUID;
 
 public class YamlLevelsHolder extends ConfigurationFile implements Levels {
 
@@ -36,7 +37,7 @@ public class YamlLevelsHolder extends ConfigurationFile implements Levels {
 
     @Override
     public void loadLevelToUser(User user) {
-        user.setLevel(getLevel(user.getName()));
+        user.setLevel(getLevel(user.getUUID()));
     }
 
     @Override
@@ -45,7 +46,7 @@ public class YamlLevelsHolder extends ConfigurationFile implements Levels {
     }
 
     private void saveLevelFromUser(User user, boolean remove) {
-        saveLevel(user.getName(), user.getLevel());
+        saveLevel(user.getUUID(), user.getLevel());
         if (remove) AntiCheat.getManager().getUserManager().remove(user);
     }
 
@@ -62,8 +63,8 @@ public class YamlLevelsHolder extends ConfigurationFile implements Levels {
         return;
     }
 
-    private int getLevel(String name) {
-        ConfigValue<Integer> level = new ConfigValue<Integer>(name, false);
+    private int getLevel(UUID uuid) {
+        ConfigValue<Integer> level = new ConfigValue<Integer>(uuid.toString(), false);
         if (level.hasValue()) {
             return level.getValue();
         } else {
@@ -71,7 +72,7 @@ public class YamlLevelsHolder extends ConfigurationFile implements Levels {
         }
     }
 
-    private void saveLevel(String name, int level) {
-        new ConfigValue<Integer>(name, false).setValue(new Integer(level));
+    private void saveLevel(UUID uuid, int level) {
+        new ConfigValue<Integer>(uuid.toString(), false).setValue(new Integer(level));
     }
 }

--- a/src/main/java/net/gravitydevelopment/anticheat/event/EventListener.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/event/EventListener.java
@@ -30,10 +30,11 @@ import org.bukkit.event.Listener;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class EventListener implements Listener {
     private static final Map<CheckType, Integer> USAGE_LIST = new EnumMap<CheckType, Integer>(CheckType.class);
-    private static final Map<String, Integer> DECREASE_LIST = new HashMap<String, Integer>();
+    private static final Map<UUID, Integer> DECREASE_LIST = new HashMap<UUID, Integer>();
     private static final CheckManager CHECK_MANAGER = AntiCheat.getManager().getCheckManager();
     private static final Backend BACKEND = AntiCheat.getManager().getBackend();
     private static final AntiCheat PLUGIN = AntiCheat.getManager().getPlugin();
@@ -41,7 +42,7 @@ public class EventListener implements Listener {
     private static final Configuration CONFIG = AntiCheat.getManager().getConfiguration();
 
     public static void log(String message, Player player, CheckType type) {
-        User user = getUserManager().getUser(player.getName());
+        User user = getUserManager().getUser(player.getUniqueId());
         if (user != null) { // npc
             logCheat(type, user);
             if (user.increaseLevel(type) && message != null) {
@@ -54,7 +55,7 @@ public class EventListener implements Listener {
     private static void logCheat(CheckType type, User user) {
         USAGE_LIST.put(type, getCheats(type) + 1);
         // Ignore plugins that are creating NPCs with no names (why the hell)
-        if (user != null && user.getName() != null) {
+        if (user != null && user.getUUID() != null) {
             type.logUse(user);
             if (CONFIG.getConfig().enterprise.getValue() && CONFIG.getEnterprise().loggingEnabled.getValue()) {
                 CONFIG.getEnterprise().database.logEvent(user, type);
@@ -77,34 +78,34 @@ public class EventListener implements Listener {
     private static void removeDecrease(User user) {
         int x = 0;
         // Ignore plugins that are creating NPCs with no names
-        if (user.getName() != null) {
-            if (DECREASE_LIST.get(user.getName()) != null) {
-                x = DECREASE_LIST.get(user.getName());
+        if (user.getUUID() != null) {
+            if (DECREASE_LIST.get(user.getUUID()) != null) {
+                x = DECREASE_LIST.get(user.getUUID());
                 x -= 2;
                 if (x < 0) {
                     x = 0;
                 }
             }
-            DECREASE_LIST.put(user.getName(), x);
+            DECREASE_LIST.put(user.getUUID(), x);
         }
     }
 
     public static void decrease(Player player) {
-        User user = getUserManager().getUser(player.getName());
+        User user = getUserManager().getUser(player.getUniqueId());
         // Ignore plugins that are creating NPCs with no names
-        if (user.getName() != null) {
+        if (user.getUUID() != null) {
             int x = 0;
 
-            if (DECREASE_LIST.get(user.getName()) != null) {
-                x = DECREASE_LIST.get(user.getName());
+            if (DECREASE_LIST.get(user.getUUID()) != null) {
+                x = DECREASE_LIST.get(user.getUUID());
             }
 
             x += 1;
-            DECREASE_LIST.put(user.getName(), x);
+            DECREASE_LIST.put(user.getUUID(), x);
 
             if (x >= 10) {
                 user.decreaseLevel();
-                DECREASE_LIST.put(user.getName(), 0);
+                DECREASE_LIST.put(user.getUUID(), 0);
             }
         }
     }

--- a/src/main/java/net/gravitydevelopment/anticheat/event/InventoryListener.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/event/InventoryListener.java
@@ -56,13 +56,13 @@ public class InventoryListener extends EventListener {
     @EventHandler
     public void onInventoryOpen(InventoryOpenEvent event) {
         if (event.getInventory().getType() != InventoryType.BEACON) {
-            getUserManager().getUser(event.getPlayer().getName()).setInventorySnapshot(event.getInventory().getContents());
+            getUserManager().getUser(event.getPlayer().getUniqueId()).setInventorySnapshot(event.getInventory().getContents());
         }
     }
 
     @EventHandler
     public void onInventoryClose(InventoryCloseEvent event) {
-        User user = getUserManager().getUser(event.getPlayer().getName());
+        User user = getUserManager().getUser(event.getPlayer().getUniqueId());
         if (user != null) {
             user.removeInventorySnapshot();
         }

--- a/src/main/java/net/gravitydevelopment/anticheat/event/PlayerListener.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/event/PlayerListener.java
@@ -192,7 +192,7 @@ public class PlayerListener extends EventListener {
     public void onPlayerQuit(PlayerQuitEvent event) {
         getBackend().garbageClean(event.getPlayer());
 
-        User user = getUserManager().getUser(event.getPlayer().getName());
+        User user = getUserManager().getUser(event.getPlayer().getUniqueId());
 
         getConfig().getLevels().saveLevelFromUser(user);
 
@@ -291,7 +291,7 @@ public class PlayerListener extends EventListener {
 
         getBackend().logJoin(player);
 
-        User user = new User(player.getName());
+        User user = new User(player.getUniqueId());
         user.setIsWaitingOnLevelSync(true);
         getConfig().getLevels().loadLevelToUser(user);
         getUserManager().addUser(user);
@@ -318,7 +318,7 @@ public class PlayerListener extends EventListener {
             final double y = distance.getYDifference();
             getBackend().logAscension(player, from.getY(), to.getY());
 
-            final User user = getUserManager().getUser(player.getName());
+            final User user = getUserManager().getUser(player.getUniqueId());
             user.setTo(to.getX(), to.getY(), to.getZ());
             
             KillAuraCheck.doMove(event);
@@ -445,7 +445,7 @@ public class PlayerListener extends EventListener {
     public void checkFly(PlayerMoveEvent event) {
         // Check flight on highest to make sure other plugins have a chance to change the values first.
         final Player player = event.getPlayer();
-        final User user = getUserManager().getUser(player.getName());
+        final User user = getUserManager().getUser(player.getUniqueId());
         final Location from = event.getFrom();
         final Location to = event.getTo();
 

--- a/src/main/java/net/gravitydevelopment/anticheat/manage/UserManager.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/manage/UserManager.java
@@ -29,6 +29,7 @@ import org.bukkit.ChatColor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class UserManager {
     private List<User> users = new ArrayList<User>();
@@ -49,19 +50,19 @@ public class UserManager {
     }
 
     /**
-     * Get a user with the given name
+     * Get a user with the given UUID
      *
-     * @param name Name
-     * @return User with name
+     * @param uuid UUID
+     * @return User with UUID
      */
-    public User getUser(String name) {
+    public User getUser(UUID uuid) {
         for (User user : users) {
-            if (user.getName().equalsIgnoreCase(name)) {
+            if (user.getUUID().equals(uuid)) {
                 return user;
             }
         }
         // Otherwise try to load them
-        User user = new User(name);
+        User user = new User(uuid);
         user.setIsWaitingOnLevelSync(true);
         config.getLevels().loadLevelToUser(user);
         return user;
@@ -121,11 +122,11 @@ public class UserManager {
     /**
      * Get a user's level, or 0 if the player isn't found
      *
-     * @param name Name of the player
+     * @param uuid UUID of the player
      * @return player level
      */
-    public int safeGetLevel(String name) {
-        User user = getUser(name);
+    public int safeGetLevel(UUID uuid) {
+        User user = getUser(uuid);
         if (user == null) {
             return 0;
         } else {
@@ -136,11 +137,11 @@ public class UserManager {
     /**
      * Set a user's level
      *
-     * @param name  Name of the player
+     * @param uuid UUID of the player
      * @param level Group to set
      */
-    public void safeSetLevel(String name, int level) {
-        User user = getUser(name);
+    public void safeSetLevel(UUID uuid, int level) {
+        User user = getUser(uuid);
         if (user != null) {
             user.setLevel(level);
         }
@@ -149,10 +150,10 @@ public class UserManager {
     /**
      * Reset a user
      *
-     * @param name Name of the user
+     * @param uuid UUID of the user
      */
-    public void safeReset(String name) {
-        User user = getUser(name);
+    public void safeReset(UUID uuid) {
+        User user = getUser(uuid);
         if (user != null) {
             user.resetLevel();
         }

--- a/src/main/java/net/gravitydevelopment/anticheat/util/User.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/util/User.java
@@ -57,7 +57,7 @@ public class User {
      */
     public User(UUID uuid) {
         this.uuid = uuid;
-        this.name = getPlayer().getName();
+        this.name = getPlayer() != null && getPlayer().isOnline() ? getPlayer().getName() : "";
         this.id = getPlayer() != null && getPlayer().isOnline() ? getPlayer().getEntityId() : -1;
     }
 
@@ -105,7 +105,7 @@ public class User {
      * @return Player
      */
     public Player getPlayer() {
-        return Bukkit.getPlayer(uuid);
+    	return Bukkit.getPlayer(uuid);
     }
 
     /**

--- a/src/main/java/net/gravitydevelopment/anticheat/util/User.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/util/User.java
@@ -31,8 +31,10 @@ import org.bukkit.inventory.ItemStack;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class User {
+    private final UUID uuid;
     private final String name;
     private final int id;
     private int level = 0;
@@ -51,11 +53,32 @@ public class User {
     /**
      * Initialize an AntiCheat user
      *
+     * @param uuid Player's UUID
+     */
+    public User(UUID uuid) {
+        this.uuid = uuid;
+        this.name = getPlayer().getName();
+        this.id = getPlayer() != null && getPlayer().isOnline() ? getPlayer().getEntityId() : -1;
+    }
+
+    /**
+     * Initialize an AntiCheat user
+     *
      * @param name Player's name
      */
-    public User(String name) {
+/*    public User(String name) {
+        this.uuid = Bukkit.getPlayer(name).getUniqueId();
         this.name = name;
         this.id = getPlayer() != null && getPlayer().isOnline() ? getPlayer().getEntityId() : -1;
+    }
+*/
+    /**
+     * Get the player's UUID
+     *
+     * @return Player UUID
+     */
+    public UUID getUUID() {
+        return uuid;
     }
 
     /**
@@ -82,7 +105,7 @@ public class User {
      * @return Player
      */
     public Player getPlayer() {
-        return Bukkit.getPlayer(name);
+        return Bukkit.getPlayer(uuid);
     }
 
     /**
@@ -117,7 +140,7 @@ public class User {
      */
     public boolean increaseLevel(CheckType type) {
         if (getPlayer() != null && getPlayer().isOnline()) {
-            if (silentMode() && type.getUses(name) % 4 != 0) {
+            if (silentMode() && type.getUses(uuid) % 4 != 0) {
                 // Prevent silent mode from increasing the level way too fast
                 return false;
             } else {
@@ -181,7 +204,7 @@ public class User {
     public void resetLevel() {
         level = 0;
         for (CheckType type : CheckType.values()) {
-            type.clearUse(name);
+            type.clearUse(uuid);
         }
     }
 
@@ -402,6 +425,6 @@ public class User {
 
     @Override
     public String toString() {
-        return "User {name = " + name + ", level = " + level + "}";
+        return "User {name = " + getName() + ", level = " + level + "}";
     }
 }

--- a/src/main/java/net/gravitydevelopment/anticheat/util/rule/Rule.java
+++ b/src/main/java/net/gravitydevelopment/anticheat/util/rule/Rule.java
@@ -160,12 +160,12 @@ public class Rule {
         map.put("player_check", type.name().toLowerCase());
         map.put("player_level", user.getLevel());
         map.put("player_group", user.getGroup() != null ? user.getGroup().getName().toLowerCase() : "low");
-        map.put("player_name", user.getName().toLowerCase());
+        map.put("player_uuid", user.getUUID().toString());
         map.put("player_gamemode", user.getPlayer().getGameMode().toString());
         map.put("player_world", user.getPlayer().getWorld().getName());
         map.put("player_health", user.getPlayer().getHealth());
         for (CheckType t : CheckType.values()) {
-            map.put("check_" + t.name().toLowerCase(), t.getUses(user.getName()));
+            map.put("check_" + t.name().toLowerCase(), t.getUses(user.getUUID()));
         }
         return map;
     }


### PR DESCRIPTION
Use UUIDs everywhere but in log messages and store players' cheat levels with their UUID too.

`isUUIDFormatted` and `convertToUUID` in ConfigurationTable take care of the conversion from names to UUIDs in existing databases.

It should resolve #1.