### PR TITLE
make getHandlers() static

### DIFF
--- a/src/main/java/com/rammelkast/anticheatreloaded/api/CheckFailEvent.java
+++ b/src/main/java/com/rammelkast/anticheatreloaded/api/CheckFailEvent.java
@@ -59,7 +59,7 @@ public class CheckFailEvent extends Event {
         return type;
     }
 
-    public HandlerList getHandlers() {
+    public static HandlerList getHandlers() {
         return handlers;
     }
 


### PR DESCRIPTION
Should fix the issue mentioned in #76 . However, Maven seems to have some trouble fetching the SpigotAPI dependencies, so I was unable to test it.